### PR TITLE
Don't try to get FTP response if connection fails

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -32,7 +32,9 @@ func (ftp *FTP) debugInfo(s string) {
 
 func (ftp *FTP) Connect(host string, port int) {
 	addr := fmt.Sprintf("%s:%d", host, port)
-	ftp.conn, ftp.Error = net.Dial("tcp", addr)
+	if ftp.conn, ftp.Error = net.Dial("tcp", addr); ftp.Error != nil {
+		return
+	}
 	ftp.Response()
 	ftp.host = host
 	ftp.port = port


### PR DESCRIPTION
If the FTP connection fails, then `ftp.conn` will be `nil` and `ftp.Response()` will panic when trying to use the `nil` connection. Therefore, return immediately if an error is returned by `net.Dial()`.